### PR TITLE
fix self-recursive macro replacement

### DIFF
--- a/external/test_cases.sh
+++ b/external/test_cases.sh
@@ -403,6 +403,8 @@ run_test pp_11 '#if 2*2 - 3*1\n int n = 10; \n #endif\n int main() {return 164 +
 run_test pp_12 '#ifdef TEST\n int n = 10; \n #else \n int n = 20; \n #endif\n int main() {return 154 + n;}' 174
 run_test pp_13 '#if 1\n int n = 10; \n #else \n int n = 20; \n #endif\n int main() {return 164 + n;}' 174
 
+run_test pp_14 '#define stdin (stdin)\n int main() {int stdin;return 174;}' 174
+
 run_test typedef_1 'typedef int TEST; TEST main(){return 174;}' 174
 run_test typedef_2 'typedef struct A TEST; int main(){ TEST *p; return 174;}' 174
 run_test typedef_3 'typedef void *TEST; int main(){  return 166 + sizeof(TEST);}' 174

--- a/preprocess.c
+++ b/preprocess.c
@@ -22,6 +22,7 @@ void *calloc();
 void *memcpy();
 int fprintf();
 int snprintf();
+int strcmp();
 char *strcpy();
 
 #endif
@@ -349,6 +350,9 @@ void process_define_line(Token **post, Token **pre, Token *tok) {
 
   while (expand_define(&tok, tok), tok->kind != TK_NEWLINE) {
     cur->next = tok;
+    if (equal_kind(tok, TK_IDENT) && strcmp(tok->ident_str, define_str) == 0) {
+      tok->is_recursived = true;
+    }
     cur = cur->next;
 
     tok = tok->next;
@@ -386,6 +390,11 @@ void process_undef_line(Token **post, Token **pre, Token *tok) {
 // 最悪でもTK_NEWLINEで止まる
 void expand_define(Token **pre, Token *tok) {
   if (!equal_kind(tok, TK_IDENT)) {
+    *pre = tok;
+    return;
+  }
+
+  if (tok->is_recursived) {
     *pre = tok;
     return;
   }

--- a/tokenize.h
+++ b/tokenize.h
@@ -59,6 +59,7 @@ struct Token {
 
   // for TK_IDENT
   char *ident_str;
+  bool is_recursived;
 
   // for str-literal
   StrLiteral *str_literal;


### PR DESCRIPTION
#51 
`#define stdin (stdin)` のような自己再帰だけ対処した