### PR TITLE
Impl function like macro

### DIFF
--- a/external/test_cases.sh
+++ b/external/test_cases.sh
@@ -462,7 +462,10 @@ run_test initialize_list_4 'int a[] = {1,2,3,4}; int main(){return 164+a[0]+a[1]
 run_test initialize_list_5 'int main(){int a[4] = {1,2,3,4}; return 164+a[0]+a[1]+a[2]+a[3];}' 174
 run_test initialize_list_6 'struct Test{int n;int *p;}; int main(){ struct Test t = {10,(void *)0}; return 164 + t.n + (t.p ? 10 : 0);}' 174
 
-run_test function_like_macro_1 '#define DOUBLE(a) 2*a\n int main(){return DOUBLE(87);}' 174
+run_test function_like_macro_1 '#define DOUBLE(a) 174\n int main(){return DOUBLE(87);}' 174
+run_test function_like_macro_2 '#define DOUBLE(a) 2*a\n int main(){return DOUBLE(87);}' 174
+run_test function_like_macro_3 '#define TEST(a,b) 10*a + 2 * b \n int main(){return TEST(10,37);}' 174
+run_test function_like_macro_4 '#define DECL(a,b) int a = b \n int main(){DECL(n,174); return n;}' 174
 
 #run_test 316 'struct A{int a; int b; int *p;}; struct A f(void) {struct A u; u.a = 100; u.b = 74; u.p = 0; return u;} int main(void){struct A u = f(); struct A *p = &u; if (u.p) {return 3;} else {return p->a + p->b;}}' 174
 #run_test 317 'struct A{int a; int b; int *p;}; struct A f(void) {struct A u; u.a = 100; u.b = 74; u.p = 0; return u;} int g (struct A *p) {return p->a + p->b;} int main(void){struct A u = f(); struct A *p = &u; if (u.p) {return 3;} else {return g(p);}}' 174

--- a/external/test_cases.sh
+++ b/external/test_cases.sh
@@ -462,6 +462,8 @@ run_test initialize_list_4 'int a[] = {1,2,3,4}; int main(){return 164+a[0]+a[1]
 run_test initialize_list_5 'int main(){int a[4] = {1,2,3,4}; return 164+a[0]+a[1]+a[2]+a[3];}' 174
 run_test initialize_list_6 'struct Test{int n;int *p;}; int main(){ struct Test t = {10,(void *)0}; return 164 + t.n + (t.p ? 10 : 0);}' 174
 
+run_test function_like_macro_1 '#define DOUBLE(a) 2*a\n int main(){return DOUBLE(87);}' 174
+
 #run_test 316 'struct A{int a; int b; int *p;}; struct A f(void) {struct A u; u.a = 100; u.b = 74; u.p = 0; return u;} int main(void){struct A u = f(); struct A *p = &u; if (u.p) {return 3;} else {return p->a + p->b;}}' 174
 #run_test 317 'struct A{int a; int b; int *p;}; struct A f(void) {struct A u; u.a = 100; u.b = 74; u.p = 0; return u;} int g (struct A *p) {return p->a + p->b;} int main(void){struct A u = f(); struct A *p = &u; if (u.p) {return 3;} else {return g(p);}}' 174
 #run_test_with_supplement1 318 'struct A{int a; int b; int *p;}; struct A q(void); int g (struct A *p) {return p->a + p->b;} int main(void){struct A u = q(); struct A *p = &u; if (u.p) {return 3;} else {return g(p);}}' 174

--- a/tokenize.h
+++ b/tokenize.h
@@ -11,6 +11,9 @@ typedef enum TokenKind {
   TK_NEWLINE,
   TK_EOF,
 
+  // for func-like macro
+  TK_MACRO_ARG,
+
   // keyword
   TK_RETURN,
   TK_SIZEOF,
@@ -59,6 +62,8 @@ struct Token {
   // for preprocess & error-handling
   char *filepath;
   char *file_buf;
+  bool is_recursived;
+  int nth_arg; // for func-like macro
 
   // for TK_NUM
   long val;
@@ -68,7 +73,6 @@ struct Token {
 
   // for TK_IDENT
   char *ident_str;
-  bool is_recursived;
 
   // for str-literal
   StrLiteral *str_literal;


### PR DESCRIPTION
#68 function-like macroの基本的な部分は実装した 
展開の部分でカッコ列をまとめる部分などは未実装
(この段階では`MACRO( (1,2) , 3 )` のパースがぶっ壊れる)